### PR TITLE
resolve #1 - fix warnings new since perl 5.21.2

### DIFF
--- a/lib/Exception/Base.pm
+++ b/lib/Exception/Base.pm
@@ -1362,7 +1362,7 @@ sub matches {   ## no critic qw(ProhibitExcessComplexity)
                     local $_ = ref $self->{$key} eq 'ARRAY'
                                ? sprintf(
                                      @{$self->{$key}}[0],
-                                     @{$self->{$key}}[1..@{$self->{$key}}]
+                                     @{$self->{$key}}[1..@{$self->{$key}}-1]
                                  )
                                : $self->{$key};
                     if (ref $arrval eq 'CODE') {
@@ -1393,7 +1393,7 @@ sub matches {   ## no critic qw(ProhibitExcessComplexity)
             local $_ = ref $self->{$key} eq 'ARRAY'
                        ? sprintf(
                              @{$self->{$key}}[0],
-                             @{$self->{$key}}[1..@{$self->{$key}}]
+                             @{$self->{$key}}[1..@{$self->{$key}}-1]
                          )
                        : $self->{$key};
 
@@ -1613,7 +1613,7 @@ sub _string_attributes {
     my ($self) = @_;
 
     return map { ref $_ eq 'ARRAY'
-                 ? sprintf(@$_[0], @$_[1..@$_])
+                 ? sprintf(@$_[0], @$_[1..@$_-1])
                  : $_ }
            grep { defined $_ and (ref $_ or $_ ne '') }
            map { $self->{$_} }


### PR DESCRIPTION
Redundant argument in %s - this is because the various calls to the
sprintf function offset the arrays by 1 (since the first element of
the array is the sprintf string) but use @_ (the number of elements
in the array) in the range: 1 .. @_

since it's offset by 1 we are going beyond the end of the array and
so sprintf consequently warns that we sent more arguments than it
expected. fix this by using @_ -1 in the range (number of elements
in the array minus 1)
