### PR TITLE
Correctly rethrow exceptions from unrelated classes

### DIFF
--- a/README
+++ b/README
@@ -119,7 +119,7 @@ AUTHOR
 
 LICENSE
 
-    Copyright (c) 2007-2015 Piotr Roszatycki <dexter@cpan.org>.
+    Copyright (c) 2007-2018 Piotr Roszatycki <dexter@cpan.org>.
 
     This program is free software; you can redistribute it and/or modify it
     under the same terms as Perl itself.

--- a/README.md
+++ b/README.md
@@ -992,7 +992,7 @@ Piotr Roszatycki &lt;dexter@cpan.org>
 
 # LICENSE
 
-Copyright (c) 2007-2015 Piotr Roszatycki &lt;dexter@cpan.org>.
+Copyright (c) 2007-2018 Piotr Roszatycki &lt;dexter@cpan.org>.
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.

--- a/lib/Exception/Base.pm
+++ b/lib/Exception/Base.pm
@@ -1030,7 +1030,7 @@ sub throw {
 
     if (not ref $self) {
         # CLASS->throw
-        if (not ref $_[0]) {
+        if (not ref $_[0] or not ref($_[0])->isa('Exception::Base')) {
             # Throw new exception
             if (scalar @_ % 2 == 0) {
                 # Throw normal error

--- a/lib/Exception/Base.pm
+++ b/lib/Exception/Base.pm
@@ -2352,7 +2352,7 @@ Piotr Roszatycki <dexter@cpan.org>
 
 =head1 LICENSE
 
-Copyright (c) 2007-2015 Piotr Roszatycki <dexter@cpan.org>.
+Copyright (c) 2007-2018 Piotr Roszatycki <dexter@cpan.org>.
 
 This program is free software; you can redistribute it and/or modify it
 under the same terms as Perl itself.

--- a/t/tlib/Exception/BaseTest.pm
+++ b/t/tlib/Exception/BaseTest.pm
@@ -197,6 +197,15 @@ sub test_throw {
     $self->assert_equals('Throw', $obj10->{myattr});
     $self->assert_null($obj10->{message});
     $self->assert_equals('Exception::BaseTest', $obj1->{caller_stack}->[0]->[0]);
+
+    # Exception of other class
+    my $other_class = 'My::Other::Exception';
+    eval {
+        Exception::Base->throw(bless {}, $other_class);
+    };
+    my $e = Exception::Base->catch;
+    $self->assert($e->isa('Exception::Base'));
+    $self->assert($e->message->isa($other_class));
 }
 
 sub test_to_string {


### PR DESCRIPTION
Solves https://rt.cpan.org/Public/Bug/Display.html?id=79655
by not assuming the first argument to throw must be an Exception::Base
if it's a reference. If it doesn't inherit from Exception::Base, it's
wrapped in a new Exception::Base object which is then thrown.